### PR TITLE
Fix typo in 02RL Jupyter Notebook

### DIFF
--- a/02_RL.ipynb
+++ b/02_RL.ipynb
@@ -340,7 +340,7 @@
    "outputs": [],
    "source": [
     "def epsilon_gen(eps_start=1.0, eps_decay=0.99999, eps_min=0.05):\n",
-    "    \"\"\"Convenient generator function to generate and decy epsilon.\"\"\"\n",
+    "    \"\"\"Convenient generator function to generate and decay epsilon.\"\"\"\n",
     "    # TODO: eps starts at eps_start :)\n",
     "    eps = None\n",
     "    while True:\n",

--- a/solution/02_RL.ipynb
+++ b/solution/02_RL.ipynb
@@ -359,7 +359,7 @@
    "outputs": [],
    "source": [
     "def epsilon_gen(eps_start=1.0, eps_decay=0.99999, eps_min=0.05):\n",
-    "    \"\"\"Convenient generator function to generate and decy epsilon.\"\"\"\n",
+    "    \"\"\"Convenient generator function to generate and decay epsilon.\"\"\"\n",
     "    eps = eps_start\n",
     "    while True:\n",
     "        yield eps\n",


### PR DESCRIPTION
I modified the comment under "Decay Epsilon with Generator" in the 02RL notebook from:


"""Convenient generator function to generate and decy epsilon."""
to:

"""Convenient generator function to generate and decay epsilon."""
I made the same modification in the 02RL file under the solution folder.