### PR TITLE
Fix GAE computation also in "non-solutions" notebook

### DIFF
--- a/06_PPO.ipynb
+++ b/06_PPO.ipynb
@@ -496,7 +496,7 @@
     "        )\n",
     "        advantages[t] = td_error + gamma * gae_lambda * next_non_terminal * last_gae_lambda\n",
     "        next_return = segment.values[t]\n",
-    "        last_gae_lambda = advantages[t]n",
+    "        last_gae_lambda = advantages[t]\n",
     "\n",
     "    returns = advantages + segment.values\n",
     "    return advantages, returns"


### PR DESCRIPTION
This MR fixes the GAE computation also in "non-solutions" notebook, since it was also dropping the terminal step’s contribution to A_(t-1) :slightly_smiling_face: 